### PR TITLE
[CB-2649] fix

### DIFF
--- a/framework/ext/src/org/apache/cordova/util/FileUtils.java
+++ b/framework/ext/src/org/apache/cordova/util/FileUtils.java
@@ -52,10 +52,8 @@ public class FileUtils {
     // init APP_TMP_DIR with a random value
     static {
         Random gen = new Random();
-        APP_TMP_DIR = "tmp" + gen.nextInt();
+        APP_TMP_DIR = "tmp" + Math.abs(gen.nextInt());
     }
-
-   // private static long APP_TMP_DIR = 
 
     /**
      * Reads file as byte array.


### PR DESCRIPTION
Removes app temp directory name generation based on the CordovaExtension getAppID method, and replaces it with random generation. Also catches offending exception with appropriate error message logging
