### PR TITLE
Fix create script for Linux

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -56,6 +56,19 @@ function on_error {
     [ -d "$PROJECT_PATH" ] && rm -rf "$PROJECT_PATH"
 }
 
+function replace {
+    local pattern=$1
+    local filename=$2
+    # Mac OS X requires -i argument
+    if [[ "$OSTYPE" =~ "darwin" ]]
+    then
+        /usr/bin/sed -i '' -e $pattern "$filename"
+    elif [[ "$OSTYPE" =~ "linux" ]]
+    then
+        /bin/sed -i -e $pattern "$filename"
+    fi
+}
+
 # we do not want the script to silently fail
 trap on_error ERR
 trap on_exit EXIT
@@ -79,13 +92,13 @@ then
 	(cd "$BUILD_PATH" && "$ANT" create -Dproject.path="$PROJECT_PATH" &> /dev/null )
     # interpolate the activity and package into config.xml
     echo "Updating config.xml ..."
-    sed -i '' -e "s/__NAME__/${NAME}/g" "$MANIFEST_PATH"
-    sed -i '' -e "s/__PACKAGE__/${PACKAGE}/g" "$MANIFEST_PATH"
+    replace "s/__NAME__/${NAME}/g" "$MANIFEST_PATH"
+    replace "s/__PACKAGE__/${PACKAGE}/g" "$MANIFEST_PATH"
 else
 	# copy project template if in distribution
 	echo "Copying assets and resources ..."
 	cp -r "$BUILD_PATH/sample/." "$PROJECT_PATH"
     echo "Updating config.xml ..."
-    sed -i '' -e "s/cordovaExample/${NAME}/g" "$MANIFEST_PATH"
-    sed -i '' -e "s/org.apache.cordova.example/${PACKAGE}/g" "$MANIFEST_PATH"
+    replace "s/cordovaExample/${NAME}/g" "$MANIFEST_PATH"
+    replace "s/org.apache.cordova.example/${PACKAGE}/g" "$MANIFEST_PATH"
 fi


### PR DESCRIPTION
This fix is copied from the Android create script.
sed on OSX requires the `-i` parameter to include an extension (in this case an empty string), whereas it is not required on Linux (leading to the empty string being interpreted as the filename).
