### PR TITLE
Updated run and build scripts with new debug token feature

### DIFF
--- a/blackberry10/bin/templates/project/cordova/lib/build
+++ b/blackberry10/bin/templates/project/cordova/lib/build
@@ -18,11 +18,7 @@
 
 var path = require("path"),
     command = require("commander"),
-    jWorkflow = require("jWorkflow"),
-    localize = require("./localize"),
-    logger = require("./logger"),
     projectProperties = require("../../project.json"),
-    debugTokenHelper = require("./debugtoken-helper"),
     bbwpArgv = [
         process.argv[0],
         path.resolve(path.join(__dirname, process.argv[1])),
@@ -30,12 +26,10 @@ var path = require("path"),
         "-o",
         path.resolve(path.join(__dirname, "..", "..", "build"))
     ],
-    built = false,
-    debugtoken = false;
-
-function getTarget() {
-    return typeof command.args[0] === "string" ? command.args[0] : undefined;
-}
+    jWorkflow = require("jWorkflow"),
+    childProcess = require("child_process"),
+    pkgrUtils = require("./packager-utils"),
+    commandStr;
 
 function copyArgIfExists(arg) {
     if (command[arg]) {
@@ -44,49 +38,14 @@ function copyArgIfExists(arg) {
     }
 }
 
-function createDebugtoken(previous, baton) {
-    var keystorepass = command["keystorepass"] ? command["keystorepass"] : projectProperties.keystorepass;
-    baton.take();
-    logger.info(localize.translate("PROGRESS_WILL_CREATE_DEBUG_TOKEN"));
-    debugTokenHelper.createToken(projectProperties, getTarget(), keystorepass, function (code) {
-        if (code === 0) {
-            debugtoken = true;
-        }
-
-        baton.pass();
-    });
-}
-
-function deployDebugToken(previous, baton) {
-    baton.take();
-
-    // If in debug build and debug token was created, deploy the debug token and wait until the deployment is finished
-    if (debugtoken) {
-        logger.info(localize.translate("PROGRESS_WILL_DEPLOY_DEBUG_TOKEN"));
-        debugTokenHelper.deployToken(projectProperties, getTarget(), function () {
-            baton.pass();
-        });
-    } else {
-        baton.pass();
-    }
-}
-
 function doDebugBuild() {
-    built = true;
-
     //build in debug mode by default
     bbwpArgv.push("-d");
 
-    // In debug build, it needs to create debug token first
-    jWorkflow.order(createDebugtoken)
-             .andThen(deployDebugToken)
-             .andThen(build)
-             .start();
+    build();
 }
 
 function doReleaseBuild() {
-    built = true;
-
     //Note: Packager refers to signing password as "password" not "keystorepass"
     if (command["keystorepass"]) {
         bbwpArgv.push("--password");
@@ -95,7 +54,8 @@ function doReleaseBuild() {
         bbwpArgv.push("--password");
         bbwpArgv.push( projectProperties.keystorepass);
     } else {
-        throw "No signing password provided. Please use --keystorepass via command-line or enter a value for keystorepass in project.json";
+        console.log("No signing password provided. Please use --keystorepass via command-line or enter a value for keystorepass in project.json");
+        process.exit(2);
     }
 
     copyArgIfExists("buildId");
@@ -107,68 +67,64 @@ function build() {
     copyArgIfExists("params");
     copyArgIfExists("loglevel");
 
-    //Overrite process.argv, before calling packager
+    //Overwrite process.argv, before calling packager
     process.argv = bbwpArgv;
 
     //Delete cached commander object. It will conflict with the packagers commander
     delete require.cache[require.resolve("commander")];
     delete require.cache[require.resolve("commander/lib/commander")];
 
-    //Package app. If successfull call run
-    require("./packager").start(run);
+    require("./packager").start(function() {});
 }
 
-function run() {
-    var target = getTarget();
-
-    //Overrite process.argv, before calling run
-    process.argv = [
-        process.argv[0],
-        process.argv[1],
-    ];
-
-    if (target) {
-        process.argv.push(target);
+function postClean() {
+    if (command.release) {
+        doReleaseBuild();
+    } else {
+        doDebugBuild();
     }
+}
 
-    //deploy app
-    require("./run");
+function clean(previous, baton) {
+    var cleanScript;
+
+    baton.take();
+
+    cleanScript = childProcess.exec("./clean", {
+        "cwd": path.normalize(__dirname + "/.."),
+        "env": process.env
+    });
+
+    cleanScript.stdout.on("data", pkgrUtils.handleProcessOutput);
+    cleanScript.stderr.on("data", pkgrUtils.handleProcessOutput);
+
+    cleanScript.on("exit", function (code) {
+        baton.pass();
+    });
 }
 
 command
-    .usage('command [<target>] [-k | --keystorepass] [-b | --buildId <number>] [-p | --params <json>] [-ll | --loglevel <level>]')
-    .option('-k, --keystorepass <password>', 'Signing key password')
-    .option('-b, --buildId <num>', 'Specifies the build number for signing (typically incremented from previous signing).')
-    .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
+    .usage('[--debug] [--release] [-k | --keystorepass] [-b | --buildId <number>] [-p | --params <json>] [-ll | --loglevel <level>]')
+    .option('--debug', 'build in debug mode.')
+    .option('--release', 'build in release mode. This will sign the resulting bar.')
+    .option('-k, --keystorepass <password>', 'signing key password')
+    .option('-b, --buildId <num>', 'specifies the build number for signing (typically incremented from previous signing).')
+    .option('-p, --params <params JSON file>', 'specifies additional parameters to pass to downstream tools.')
     .option('-ll, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)');
-
-command
-    .command('release')
-    .usage('[<target>] [-k | --keystorepass] [-b | --buildId <number>] [-p | --params <json>] [-ll | --loglevel <level>]')
-    .description('    Build in release mode. This will sign the resulting bar.')
-    .option('-k, --keystorepass <password>', 'Signing key password')
-    .option('-b, --buildId <num>', 'Specifies the build number for signing (typically incremented from previous signing).')
-    .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
-    .option('-ll, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)')
-    .action(doReleaseBuild);
-
-command
-    .command('debug')
-    .usage('[<target>] [-p | --params <json>] [-ll | --loglevel <level>]')
-    .description('    Build in debug mode.')
-    .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
-    .option('-ll, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)')
-    .action(doDebugBuild);
 
 try {
     command.parse(process.argv);
 
-    //if we get here and haven't built yet then no mode was provided [debug, release], default to debug mode
-    if (!built) {
-        doDebugBuild();
+    if (command.debug && command.release) {
+        throw "Invalid build command: cannot specify both debug and release parameters."
     }
+
+    // Implicitly call clean first
+    jWorkflow.order(clean)
+             .andThen(postClean)
+             .start();
 } catch (e) {
     console.log(e);
-    process.exit();
+    process.exit(2);
 }
 

--- a/blackberry10/bin/templates/project/cordova/lib/debugtoken-helper.js
+++ b/blackberry10/bin/templates/project/cordova/lib/debugtoken-helper.js
@@ -28,6 +28,44 @@ var childProcess = require("child_process"),
     deployCallback,
     self = {};
 
+function isDebugTokenValid(pin, data) {
+    var manifests,
+        i,
+        l,
+        expiry = null,
+        pin,
+        devices = [],
+        line,
+        now = new Date();
+
+    if (!data) {
+        return false;
+    }
+
+    manifests = data.toString().replace(/[\r]/g, '').split('\n');
+
+    for (i=0, l=manifests.length; i<l; i++) {
+        if (manifests[i].indexOf("Debug-Token-Expiry-Date: ") >= 0) {
+            // Parse the expiry date
+            line = manifests[i].substring("Debug-Token-Expiry-Date: ".length);
+            expiry = new Date(line.substring(0, line.indexOf("T")) + " " + line.substring(line.indexOf("T") + 1, line.length -1) + " UTC");
+        } else if (manifests[i].indexOf("Debug-Token-Device-Id: ") >= 0) {
+            line = manifests[i].substring("Debug-Token-Device-Id: ".length);
+            devices = line.split(",");
+        }
+    }
+
+    if (expiry && expiry > now) {
+        for (i=0, l=devices.length; i<l; i++) {
+            if (parseInt(devices[i]) === parseInt(pin, 16)) {
+                return true; // The debug token is valid if not expired and device pin is included
+            }
+        }
+    }
+
+    return false;
+}
+
 function generateCreateTokenOptions(pins, password) {
     var options = [],
         i;
@@ -206,6 +244,38 @@ self.deployToken = function (projectProperties, target, callback) {
 
     // Deploy debug token recursively
     deployTokenToTargetsRecursively();
+};
+
+self.checkDebugToken = function (pin, callback) {
+    var process,
+        script = "/bin/blackberry-nativepackager",
+        nativePackager;
+
+    if (!callback || typeof callback !== "function") {
+        return;
+    }
+
+    if (!fs.existsSync(debugTokenDir)) {
+        callback(false);
+        return;
+    }
+
+    if (pkgrUtils.isWindows()) {
+        script += ".bat";
+    }
+
+    if (fs.existsSync(conf.DEPENDENCIES_TOOLS)) {
+        nativePackager = childProcess.exec(path.normalize(conf.DEPENDENCIES_TOOLS + script +" -listManifest " + debugTokenDir), {
+            "cwd": workingDir,
+            "env": process ? process.env : undefined
+        }, function (error, stdout, stderr) {
+            callback(isDebugTokenValid(pin, stdout));
+        });
+    } else {
+        throw localize.translate("EXCEPTION_MISSING_TOOLS");
+    }
+
+    return;
 };
 
 module.exports = self;

--- a/blackberry10/bin/templates/project/cordova/lib/localize.js
+++ b/blackberry10/bin/templates/project/cordova/lib/localize.js
@@ -172,11 +172,8 @@ var Localize = require("localize"),
         "WARNING_WEBSECURITY_DISABLED": {
             "en": "You have disabled all web security in this WebWorks application"
         },
-        "PROGRESS_WILL_CREATE_DEBUG_TOKEN": {
-            "en": "Will create debug token"
-        },
-        "PROGRESS_WILL_DEPLOY_DEBUG_TOKEN": {
-            "en": "Will deploy debug token"
+        "PROGRESS_DEBUG_TOKEN_IS_VALID": {
+            "en": "The existing debug token is valid"
         },
         "WARN_TARGET_NOT_EXIST": {
             "en": "The target \"$[1]\" does not exist"

--- a/blackberry10/bin/templates/project/cordova/lib/packager-validator.js
+++ b/blackberry10/bin/templates/project/cordova/lib/packager-validator.js
@@ -81,9 +81,6 @@ _self = {
         if (commandLinebuildId && !keysPassword) {
             //if --buildId was provided with NO password, throw error
             throw localize.translate("EXCEPTION_MISSING_SIGNING_PASSWORD");
-        } else if (buildId && !keysPassword) {
-            //if a buildId was provided in config.xml with NO password, throw warning
-            logger.warn(localize.translate("WARNING_SIGNING_PASSWORD_EXPECTED"));
         }
 
         //if --appdesc was provided, but the file is not existing, throw an error

--- a/blackberry10/bin/templates/project/cordova/lib/run
+++ b/blackberry10/bin/templates/project/cordova/lib/run
@@ -24,9 +24,16 @@ var childProcess = require("child_process"),
     conf = require("./conf"),
     localize = require("./localize"),
     pkgrUtils = require("./packager-utils"),
+    debugTokenHelper = require("./debugtoken-helper"),
     properties = require('../../project.json'),
     program = require('commander'),
     xml2js = require('xml2js'),
+    jWorkflow = require("jWorkflow"),
+    logger = require("./logger"),
+    pin,
+    needCreateDebugToken = false,
+    needDeployDebugToken = false,
+    commandStr,
     target,
     ip,
     password,
@@ -96,49 +103,26 @@ function execNativeDeploy(optionsArray, callback) {
 
 function checkTarget() {
     if (!target) {
-        console.log("No target exists, to add that target please run target add <name> <ip> [-t | --type <device | simulator>] [-p <password>] [--pin <devicepin>]\n");
+        console.log("No target exists, to add that target please run target add <name> <ip> [-t | --type <device | simulator>] [-p <password>] [--pin <devicepin>]");
         return false;
     }
     if (!properties.targets[target]) {
-        console.log("The target \""+target+"\" does not exist, to add that target please run target add "+target+" <ip> [-t | --type <device | simulator>] [-p <password>] [--pin <devicepin>]\n");
+        console.log("The target \""+target+"\" does not exist, to add that target please run target add "+target+" <ip> [-t | --type <device | simulator>] [-p <password>] [--pin <devicepin>]");
         return false;
     }
     if (properties.targets[target].ip) {
        ip = properties.targets[target].ip; 
     } else {
-        console.log("IP is not defined in target \""+target+"\"\n");
+        console.log("IP is not defined in target \""+target+"\"");
         return false;
     }
     if (properties.targets[target].password) {
        password = properties.targets[target].password;
     } 
     return true;
-
 }
 
-function deployAll(keys) {
-    target = keys[0];
-
-    if (target) {
-        if (checkTarget()) {
-            var options = generateOptions();
-            if (program.uninstall) {
-                uninstall(
-                    function() {
-                        keys.shift();
-                        deployAll(keys);
-                });
-            } else {
-                execNativeDeploy(options,
-                    function() {
-                        deployAll(keys);
-                });
-            }
-        }
-    }
-}
-
-function uninstall(callback) {
+function uninstall() {
     var script = "/bin/blackberry-deploy",
         nativeDeploy;
 
@@ -158,12 +142,10 @@ function uninstall(callback) {
                         var options = generateOptions(true);
                         execNativeDeploy(options,
                             function(){
-                                options = generateOptions(false);
-                                execNativeDeploy(options, callback);
+                                deploy();
                         });
                     } else {
-                        options = generateOptions(false);
-                        execNativeDeploy(options, callback);
+                        deploy();
                     }
                 });
             });
@@ -171,34 +153,138 @@ function uninstall(callback) {
     }
 }
 
-function exec(callback) {
-    program
-        .usage('command [<target>] [--no-launch] [--no-uninstall]')
-        .option('--no-uninstall', 'does not uninstall app from device')
-        .option('--no-launch', 'do not launch the app on device')
+function deploy() {
+    options = generateOptions(false);
+    execNativeDeploy(options, function (code) {
+        if (code) {
+            process.exit(2);
+        } else {
+            process.exit(0);
+        }
+    });
+}
 
-    program
-        .command('all')
-        .usage('all [--no-launch] [--no-uninstall]')
-        .description('    Deploy the app on all targets')
-        .option('--no-uninstall', 'does not uninstall app from device')
-        .option('--no-launch', 'do not launch the app on device')
-    
-    program.parse(process.argv);
-    target = program.args[0] ? program.args[0] : properties.defaultTarget
+function checkDebugtoken(previous, baton) {
+    baton.take();
 
-    if (target === "all") {
-        deployAll(Object.keys(properties.targets));
-    } else {
-        if (checkTarget()) {
-            if (program.uninstall) {
-                uninstall(callback);
+    // if target has no pin, skip the debug token feature
+    if (properties.targets[target].pin) {
+        debugTokenHelper.checkDebugToken(properties.targets[target].pin, function (valid) {
+            // If the debug token is not valid, we need create new debug token
+            if (valid) {
+                // No need to create the debug token
+                logger.info(localize.translate("PROGRESS_DEBUG_TOKEN_IS_VALID"));
+                needDeployDebugToken = true;
             } else {
-                options = generateOptions(false);
-                execNativeDeploy(options, callback)
+                needCreateDebugToken = true;
             }
+            baton.pass();
+        });
+    } else {
+        baton.pass();
+    }
+}
+
+function createDebugToken(previous, baton) {
+    var keystorepass = program["keystorepass"] ? program["keystorepass"] : properties.keystorepass;
+
+    baton.take();
+
+    if (needCreateDebugToken) {
+        debugTokenHelper.createToken(properties, "all", keystorepass, function (code) {
+            if (code === 0) {
+                // Deploy the debug token if created
+                needDeployDebugToken = true;
+            }
+
+            baton.pass();
+        });
+    } else {
+            baton.pass();
+    }
+}
+
+function deployDebugToken(previous, baton) {
+    baton.take();
+
+    // If in debug build and debug token was created, deploy the debug token and wait until the deployment is finished
+    if (needDeployDebugToken) {
+        debugTokenHelper.deployToken(properties, target, function () {
+            baton.pass();
+        });
+    } else {
+        baton.pass();
+    }
+}
+
+function handleBuildOutput(data) {
+    var msg = data.toString().replace(/[\n\r]/g, '');
+    console.log(msg);
+}
+
+function build(previous, baton) {
+    var nativeDeploy;
+
+    baton.take();
+
+    nativeDeploy = childProcess.exec("./build", {
+        "cwd": path.normalize(__dirname + "/.."),
+        "env": process.env
+    });
+
+    nativeDeploy.stdout.on("data", handleBuildOutput);
+
+    nativeDeploy.stderr.on("data", handleBuildOutput);
+
+    nativeDeploy.on("exit", function (code) {
+        // If error happened during building the bar, exit
+        if (code === 2) {
+            process.exit(2);
+        }
+
+        baton.pass();
+    });
+}
+
+function postBuild() {
+    if (program.uninstall) {
+        uninstall();
+    } else {
+        deploy();
+    }
+}
+
+function exec() {
+    program
+        .usage('[--target=<id>] [-k | --keystorepass] [--no-launch] [--no-uninstall] [--no-build]')
+        .option('-k, --keystorepass <password>', 'the password of signing key; needed for creating debug token')
+        .option('--target', 'specifies the target to run the application')
+        .option('--no-uninstall', 'does not uninstall application from device')
+        .option('--no-launch', 'do not launch the application on device')
+        .option('--no-build', 'deploy the pre-built bar file and skip building');
+
+    commandStr = typeof process.argv[2] === "string" ? process.argv[2] : undefined;
+    if (commandStr && commandStr.indexOf("--target=") === 0) {
+        // Convert "--target=<id>" into "--target id"
+        process.argv[2] = "--target";
+        process.argv.splice(3, 0, commandStr.substring("--target=".length));
+    }
+
+    program.parse(process.argv);
+    target = program.args[0] ? program.args[0] : properties.defaultTarget;
+
+    if (checkTarget()) {
+        if (program.build) {
+            jWorkflow.order(checkDebugtoken)
+                     .andThen(createDebugToken)
+                     .andThen(deployDebugToken)
+                     .andThen(build)
+                     .andThen(postBuild)
+                     .start();
+        } else {
+            postBuild();
         }
     }
 }
 
-exec(null);
+exec();

--- a/blackberry10/bin/templates/project/project.json
+++ b/blackberry10/bin/templates/project/project.json
@@ -1,6 +1,5 @@
 {
     "barName": "cordova-BB10-app",
-    "keystorepass": "password",
     "defaultTarget": "",
     "targets": {}
 }

--- a/blackberry10/bin/templates/project/www/config.xml
+++ b/blackberry10/bin/templates/project/www/config.xml
@@ -24,7 +24,7 @@
 
 <widget xmlns="http://www.w3.org/ns/widgets"
         xmlns:rim="http://www.blackberry.com/ns/widgets"
-	version="1.0.0" id="default.app.id">
+	version="1.0.0.1" id="default.app.id">
 
   <name>Webworks Application</name>
 


### PR DESCRIPTION
Implemented build and run script according to the new CB specifications: …
    https://issues.apache.org/jira/browse/CB-2927
    https://issues.apache.org/jira/browse/CB-2939
Also:
1. Moved the debug token feature from "build" script to "run" script
2. Added a validation feature for debug token so it won't be created all the time
3. added --no-build and --keystorepass for "run" script
4. added a default build.id in config.xml
5. cleaned up output messages

Reviewed by: @bryanhiggins 
Tested by: @tracyli 
