### PR TITLE
AuthorID fix for device deployment

### DIFF
--- a/blackberry10/bin/templates/project/cordova/lib/config-parser.js
+++ b/blackberry10/bin/templates/project/cordova/lib/config-parser.js
@@ -295,6 +295,10 @@ function processAuthorData(data, widgetConfig) {
             widgetConfig.authorEmail = attribs.email;
         }
     }
+
+    if(data.authorId){
+        widgetConfig.authorId = sanitize(data.authorId).trim();
+    }
 }
 
 function processLicenseData(data, widgetConfig) {

--- a/blackberry10/bin/templates/project/cordova/lib/native-packager.js
+++ b/blackberry10/bin/templates/project/cordova/lib/native-packager.js
@@ -33,6 +33,7 @@ function generateTabletXMLFile(session, config) {
             id : config.id,
             versionNumber : config.version,
             author : config.author,
+            authorId: config.authorId,
             asset : [{
                 _attr : { entry : 'true', type : 'qnx/elf' },
                 _value : 'wwe'

--- a/blackberry10/bin/templates/project/www/config.xml
+++ b/blackberry10/bin/templates/project/www/config.xml
@@ -29,6 +29,8 @@
   <name>Webworks Application</name>
 
   <author>Your Name Here</author>
+  
+  <authorId>Your Author ID Here</authorId>
 
   <description>
        A sample Apache Cordova application that responds to the deviceready event.


### PR DESCRIPTION
Fix for blackberry 10 device deployment. AuthorID is required to use a debug token and build for any BB10 device.
