### PR TITLE
[CB-4268] Add --device and proper error exit code to run script

### DIFF
--- a/blackberry10/bin/templates/project/cordova/lib/run
+++ b/blackberry10/bin/templates/project/cordova/lib/run
@@ -258,6 +258,7 @@ function exec() {
     program
         .usage('[--target=<id>] [-k | --keystorepass] [--no-launch] [--no-uninstall] [--no-build]')
         .option('-k, --keystorepass <password>', 'the password of signing key; needed for creating debug token')
+        .option('--device', 'run on connected device')
         .option('--target', 'specifies the target to run the application')
         .option('--no-uninstall', 'does not uninstall application from device')
         .option('--no-launch', 'do not launch the application on device')
@@ -284,6 +285,8 @@ function exec() {
         } else {
             postBuild();
         }
+    } else {
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
- This is the minimum change required to work within CLI.
- Issues will be opened to present better error messages when the script is invoked from CLI.
- The end goal is to have automatic device discovery.

@jeffheifetz 
