### PR TITLE
Removing permissions from template since not all apps should need them

### DIFF
--- a/blackberry10/bin/templates/project/www/config.xml
+++ b/blackberry10/bin/templates/project/www/config.xml
@@ -50,12 +50,7 @@
   <content src="index.html" />
 
   <rim:permissions>
-    <rim:permit>use_camera</rim:permit>
-    <rim:permit>read_device_identifying_information</rim:permit>
     <rim:permit>access_shared</rim:permit>
-    <rim:permit>read_geolocation</rim:permit>
-    <rim:permit>record_audio</rim:permit>
-    <rim:permit>access_pimdomain_contacts</rim:permit>
   </rim:permissions>
 
 </widget>


### PR DESCRIPTION
Since all CLI apps use this as the base, it seems prudent not to add unnecessary permissions
