### PR TITLE
Call check_reqs before each script [i.e. via init]

### DIFF
--- a/blackberry10/bin/check_reqs
+++ b/blackberry10/bin/check_reqs
@@ -19,41 +19,6 @@
 #!/bin/sh
 
 BIN_DIR=$(dirname "$0")
+
+#init will execute check reqs logic
 source "$BIN_DIR/init"
-
-NODE="$CORDOVA_NODE/node"
-NPM="$CORDOVA_NODE/npm"
-JAVA=$(command -v java)
-PACKAGER="$CORDOVA_BBTOOLS/blackberry-nativepackager"
-DEPLOYER="$CORDOVA_BBTOOLS/blackberry-deploy"
-SIGNER="$CORDOVA_BBTOOLS/blackberry-signer"
-DEBUGTOKENREQUEST="$CORDOVA_BBTOOLS/blackberry-debugtokenrequest"
-
-if [ ! -x "$NODE" ]; then
-    echo node cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$NPM" ]; then
-    echo npm cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$JAVA" ]; then
-    echo java cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$PACKAGER" ]; then
-    echo blackberry-nativepackager cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$DEPLOYER" ]; then
-    echo blackberry-deploy cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$SIGNER" ]; then
-    echo blackberry-signer cannot be found on the path. Aborting.
-    EXIT_CODE=2
-elif [ ! -x "$DEBUGTOKENREQUEST" ]; then
-    echo blackberry-debugtokenrequest cannot be found on the path. Aborting.
-    EXIT_CODE=2
-else
-    "$NODE" "$BIN_DIR/check_reqs.js" "$@"
-    EXIT_CODE=0
-fi
-
-exit $EXIT_CODE
-

--- a/blackberry10/bin/check_reqs.bat
+++ b/blackberry10/bin/check_reqs.bat
@@ -17,47 +17,12 @@ goto comment
        specific language governing permissions and limitations
        under the License.
 :comment
+
 set INITCALL="%~dps0init"
 if not exist INITCALL (
     set INITCALL="%~dp0init"
 )
+
 call %INITCALL%
+if ERRORLEVEL 1 exit /B 1
 
-set FOUNDJAVA=
-for %%e in (%PATHEXT%) do (
-  for %%X in (java%%e) do (
-    if not defined FOUNDJAVA (
-      set FOUNDJAVA=%%~$PATH:X
-    )
-  )
-)
-if not exist "%CORDOVA_NODE%\node.exe" (
-  echo node cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not exist "%CORDOVA_NODE%\npm" (
-  echo npm cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not defined FOUNDJAVA (
-  echo java cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not exist "%CORDOVA_BBTOOLS%\blackberry-nativepackager" (
-  echo blackberry-nativepackager cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not exist "%CORDOVA_BBTOOLS%\blackberry-deploy" (
-  echo blackberry-deploy cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not exist "%CORDOVA_BBTOOLS%\blackberry-signer" (
-  echo blackberry-signer cannot be found on the path. Aborting.
-  exit /b 1
-)
-if not exist "%CORDOVA_BBTOOLS%\blackberry-debugtokenrequest" (
-  echo blackberry-debugtokenrequest cannot be found on the path. Aborting.
-  exit /b 1
-)
-
-"%CORDOVA_NODE%\node" "%~dp0\check_reqs.js" %*

--- a/blackberry10/bin/check_reqs.js
+++ b/blackberry10/bin/check_reqs.js
@@ -18,7 +18,7 @@
  */
 
 var MIN_NODE_VER = "0.9.9",
-    signingUtils = require('./templates/project/cordova/lib/signing-utils');
+    signingUtils = require('./lib/signing-utils');
 
 function isNodeNewerThanMin () {
     //Current version is stored as a String in format "X.X.X"
@@ -29,7 +29,7 @@ function isNodeNewerThanMin () {
 
 if (!isNodeNewerThanMin()) {
     console.log("Node version '" + process.versions.node + "' is not new enough. Please upgrade to " + MIN_NODE_VER + " or newer. Aborting.");
-    process.exit(1);
+    process.exit(2);
 }
 
 if (!signingUtils.getKeyStorePath()) {

--- a/blackberry10/bin/create
+++ b/blackberry10/bin/create
@@ -30,12 +30,6 @@ source "$BIN_DIR/init"
 CURRENT_DIR=$(pwd)
 NPM_PACKAGE_JSON="$BIN_DIR"/../package.json
 
-#Run check_reqs before doing anything and exit if there's an error
-"$BIN_DIR"/check_reqs
-if [ ${?} -ne 0 ]; then
-    exit 1
-fi
-
 #Run npm install every time (even if node_modules folder is present) to cover platform upgrade
 if [ -e "$NPM_PACKAGE_JSON" ]; then
     cd "$BIN_DIR"/..

--- a/blackberry10/bin/create.bat
+++ b/blackberry10/bin/create.bat
@@ -20,13 +20,12 @@ goto comment
 set BIN_DIR=%~dp0
 
 call "%BIN_DIR%init"
-call "%BIN_DIR%check_reqs"
-
-if "%ERRORLEVEL%" == "1" exit /B 1
+if ERRORLEVEL 1 exit /B 1
 
 if exist "%BIN_DIR%..\package.json" (
     pushd %BIN_DIR%..
     call "%CORDOVA_NODE%\npm" install
+    if ERRORLEVEL 1 exit /B 1
     popd
 )
 

--- a/blackberry10/bin/create.js
+++ b/blackberry10/bin/create.js
@@ -118,6 +118,7 @@ function copyFilesToProject() {
     utils.copyFile(path.join(BIN_DIR, "target.bat"), path.join(project_path, "cordova"));
     utils.copyFile(path.join(BIN_DIR, "lib", "target.js"), path.join(project_path, "cordova", "lib"));
     utils.copyFile(path.join(BIN_DIR, "lib", "utils.js"), path.join(project_path, "cordova", "lib"));
+    utils.copyFile(path.join(BIN_DIR, "lib", "signing-utils.js"), path.join(project_path, "cordova", "lib"));
 
     // copy repo level init script to project
     if (utils.isWindows()) {
@@ -128,6 +129,14 @@ function copyFilesToProject() {
 
     //copy VERSION file [used to identify corresponding ~/.cordova/lib directory for dependencies]
     utils.copyFile(path.join(ROOT_PROJECT_DIR, "VERSION"), path.join(project_path));
+
+    // copy repo level check_reqs script to project
+    utils.copyFile(path.join(BIN_DIR, "check_reqs.js"), path.join(project_path, "cordova"));
+    if (utils.isWindows()) {
+        utils.copyFile(path.join(BIN_DIR, "check_reqs.bat"), path.join(project_path, "cordova"));
+    } else {
+        utils.copyFile(path.join(BIN_DIR, "check_reqs"), path.join(project_path, "cordova"));
+    }
 
     // change file permission for cordova scripts because ant copy doesn't preserve file permissions
     wrench.chmodSyncRecursive(path.join(project_path,"cordova"), 0700);

--- a/blackberry10/bin/init
+++ b/blackberry10/bin/init
@@ -22,7 +22,10 @@ CORDOVA_HOME_DIR=$HOME/.cordova/lib/blackberry10/cordova/$(cat "$CURRENT_DIR/../
 LOCAL_NODE_BIN=$CORDOVA_HOME_DIR/bin/dependencies/node/bin
 LOCAL_BBTOOLS=$CORDOVA_HOME_DIR/bin/dependencies/bb-tools/bin
 
-if [ -z "$CORDOVA_NODE" ]; then
+#Skip all logic if init has already been run (env variable have been set already...)
+if [ -z "$CORDOVA_NODE" ] && [ -z "$CORDOVA_BBTOOLS" ]; then
+
+    #set CORDOVA_NODE
     if [ -x "$LOCAL_NODE_BIN" ]; then
         #set CORDOVA_NODE to local node version, if exists
         CORDOVA_NODE=$LOCAL_NODE_BIN
@@ -33,11 +36,9 @@ if [ -z "$CORDOVA_NODE" ]; then
             CORDOVA_NODE=$(dirname $NODE_PATH)
         fi
     fi
-
     export CORDOVA_NODE=$CORDOVA_NODE
-fi
 
-if [ -z "$CORDOVA_BBTOOLS" ]; then
+    #set CORDOVA_BBTOOLS
     if [ -x "$LOCAL_BBTOOLS" ]; then
         #set CORDOVA_BBTOOLS to local bbtools, if exists
         CORDOVA_BBTOOLS=$LOCAL_BBTOOLS
@@ -48,7 +49,44 @@ if [ -z "$CORDOVA_BBTOOLS" ]; then
             CORDOVA_BBTOOLS=$(dirname $BBTOOLS_PATH)
         fi
     fi
-
     export CORDOVA_BBTOOLS=$CORDOVA_BBTOOLS
+
+    #-------------check reqs---------------#
+    NODE="$CORDOVA_NODE/node"
+    NPM="$CORDOVA_NODE/npm"
+    JAVA=$(command -v java)
+    PACKAGER="$CORDOVA_BBTOOLS/blackberry-nativepackager"
+    DEPLOYER="$CORDOVA_BBTOOLS/blackberry-deploy"
+    SIGNER="$CORDOVA_BBTOOLS/blackberry-signer"
+    DEBUGTOKENREQUEST="$CORDOVA_BBTOOLS/blackberry-debugtokenrequest"
+
+    if [ ! -x "$NODE" ]; then
+        echo node cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$NPM" ]; then
+        echo npm cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$JAVA" ]; then
+        echo java cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$PACKAGER" ]; then
+        echo blackberry-nativepackager cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$DEPLOYER" ]; then
+        echo blackberry-deploy cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$SIGNER" ]; then
+        echo blackberry-signer cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    elif [ ! -x "$DEBUGTOKENREQUEST" ]; then
+        echo blackberry-debugtokenrequest cannot be found on the path. Aborting.
+        EXIT_CODE=2
+    else
+        "$NODE" "$CURRENT_DIR/check_reqs.js" "$@"
+    fi
+
+    if [ ! -z "$EXIT_CODE" ]; then
+        exit $EXIT_CODE
+    fi
 fi
 

--- a/blackberry10/bin/init.bat
+++ b/blackberry10/bin/init.bat
@@ -23,7 +23,15 @@ set CORDOVA_HOME_DIR=%HOME%\.cordova\lib\blackberry10\cordova\%CORDOVA_VERSION%
 set LOCAL_NODE_BINARY=%CORDOVA_HOME_DIR%\bin\dependencies\node\bin
 set LOCAL_BBTOOLS_BINARY=%CORDOVA_HOME_DIR%\bin\dependencies\bb-tools\bin
 
-if defined CORDOVA_NODE ( goto bbtools )
+if defined CORDOVA_NODE (
+    if exist "%CORDOVA_NODE%" (
+        if defined CORDOVA_BBTOOLS (
+            if exist "%CORDOVA_BBTOOLS%" (
+                goto end
+            )
+        )
+    )
+)
 
 if exist "%LOCAL_NODE_BINARY%" (
     set CORDOVA_NODE=%LOCAL_NODE_BINARY%
@@ -39,10 +47,6 @@ if exist "%LOCAL_NODE_BINARY%" (
     )
 )
 
-:bbtools
-
-if defined CORDOVA_BBTOOLS ( exit /B )
-
 if exist "%LOCAL_BBTOOLS_BINARY%" (
     set CORDOVA_BBTOOLS=%LOCAL_BBTOOLS_BINARY%
 ) else (
@@ -56,3 +60,46 @@ if exist "%LOCAL_BBTOOLS_BINARY%" (
         )
     )
 )
+
+set FOUNDJAVA=
+for %%e in (%PATHEXT%) do (
+  for %%X in (java%%e) do (
+    if not defined FOUNDJAVA (
+      set FOUNDJAVA=%%~$PATH:X
+    )
+  )
+)
+if not exist "%CORDOVA_NODE%\node.exe" (
+  echo node cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not exist "%CORDOVA_NODE%\npm" (
+  echo npm cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not defined FOUNDJAVA (
+  echo java cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not exist "%CORDOVA_BBTOOLS%\blackberry-nativepackager.bat" (
+  echo blackberry-nativepackager cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not exist "%CORDOVA_BBTOOLS%\blackberry-deploy.bat" (
+  echo blackberry-deploy cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not exist "%CORDOVA_BBTOOLS%\blackberry-signer.bat" (
+  echo blackberry-signer cannot be found on the path. Aborting.
+  exit /b 2
+)
+if not exist "%CORDOVA_BBTOOLS%\blackberry-debugtokenrequest.bat" (
+  echo blackberry-debugtokenrequest cannot be found on the path. Aborting.
+  exit /b 2
+)
+
+"%CORDOVA_NODE%\node" "%~dp0\check_reqs.js" %*
+
+:end
+
+exit /b 0

--- a/blackberry10/bin/lib/signing-utils.js
+++ b/blackberry10/bin/lib/signing-utils.js
@@ -1,0 +1,65 @@
+var fs = require('fs'),
+    path = require('path'),
+    os = require('os'),
+    childProcess = require('child_process'),
+    AUTHOR_P12 = "author.p12",
+    BBIDTOKEN = "bbidtoken.csk",
+    CSK = "barsigner.csk",
+    DB = "barsigner.db",
+    _self;
+
+function getDefaultPath(file) {
+    // The default location where signing key files are stored will vary based on the OS:
+    // Windows XP: %HOMEPATH%\Local Settings\Application Data\Research In Motion
+    // Windows Vista and Windows 7: %HOMEPATH%\AppData\Local\Research In Motion
+    // Mac OS: ~/Library/Research In Motion
+    // UNIX or Linux: ~/.rim
+    var p = "";
+    if (os.type().toLowerCase().indexOf("windows") >= 0) {
+        // Try Windows XP location
+        p = process.env.HOMEDRIVE + process.env.HOMEPATH + "\\Local Settings\\Application Data\\Research In Motion\\";
+        if (!fs.existsSync(p)) {
+            // Try Windows Vista and Windows 7 location
+            p = process.env.HOMEDRIVE + process.env.HOMEPATH + "\\AppData\\Local\\Research In Motion\\";
+        }
+    } else if (os.type().toLowerCase().indexOf("darwin") >= 0) {
+        // Try Mac OS location
+        p = process.env.HOME + "/Library/Research In Motion/";
+    } else if (os.type().toLowerCase().indexOf("linux") >= 0) {
+        // Try Linux location
+        p = process.env.HOME + "/.rim/";
+    }
+
+    return p + file;
+
+}
+
+function getDefaultPathIfExists(file) {
+    var p = getDefaultPath(file);
+    if (fs.existsSync(p)) {
+        return p;
+    }
+}
+
+_self = {
+    getDefaultPath: getDefaultPath,
+
+    getKeyStorePath : function () {
+        // Todo: decide where to put sigtool.p12 which is genereated and used in WebWorks SDK for Tablet OS
+        return getDefaultPathIfExists(AUTHOR_P12);
+    },
+
+    getKeyStorePathBBID: function () {
+        return getDefaultPathIfExists(BBIDTOKEN);
+    },
+
+    getCskPath : function () {
+        return getDefaultPathIfExists(CSK);
+    },
+
+    getDbPath : function () {
+        return getDefaultPathIfExists(DB);
+    }
+};
+
+module.exports = _self;

--- a/blackberry10/bin/target.bat
+++ b/blackberry10/bin/target.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\target" %*

--- a/blackberry10/bin/templates/project/cordova/build.bat
+++ b/blackberry10/bin/templates/project/cordova/build.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\build" %*

--- a/blackberry10/bin/templates/project/cordova/clean.bat
+++ b/blackberry10/bin/templates/project/cordova/clean.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\clean" %*

--- a/blackberry10/bin/templates/project/cordova/install-device.bat
+++ b/blackberry10/bin/templates/project/cordova/install-device.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\install-device" %*

--- a/blackberry10/bin/templates/project/cordova/install-emulator.bat
+++ b/blackberry10/bin/templates/project/cordova/install-emulator.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\install-emulator" %*

--- a/blackberry10/bin/templates/project/cordova/lib/list-devices.bat
+++ b/blackberry10/bin/templates/project/cordova/lib/list-devices.bat
@@ -17,4 +17,6 @@
 
 @ECHO OFF
 call "%~dp0..\init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\list-devices.js"

--- a/blackberry10/bin/templates/project/cordova/lib/list-emulator-images.bat
+++ b/blackberry10/bin/templates/project/cordova/lib/list-emulator-images.bat
@@ -17,4 +17,6 @@
 
 @ECHO OFF
 call "%~dp0..\init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\list-emulator-images.js"

--- a/blackberry10/bin/templates/project/cordova/lib/list-started-emulators.bat
+++ b/blackberry10/bin/templates/project/cordova/lib/list-started-emulators.bat
@@ -17,4 +17,6 @@
 
 @ECHO OFF
 call "%~dp0..\init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\list-started-emulators.js"

--- a/blackberry10/bin/templates/project/cordova/run.bat
+++ b/blackberry10/bin/templates/project/cordova/run.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\run" %*

--- a/blackberry10/bin/templates/project/cordova/version.bat
+++ b/blackberry10/bin/templates/project/cordova/version.bat
@@ -18,4 +18,6 @@ goto comment
        under the License.
 :comment
 call "%~dps0init"
+if ERRORLEVEL 1 exit /B 1
+
 "%CORDOVA_NODE%\node.exe" "%~dps0\lib\version" %*

--- a/blackberry10/bin/test/cordova/integration/target.js
+++ b/blackberry10/bin/test/cordova/integration/target.js
@@ -29,6 +29,7 @@ var childProcess = require('child_process'),
     configPath = utils.getPropertiesFilePath(),
     testAppCreated = false,
     _output = "",
+    _code,
     CREATE_COMMAND = path.normalize(__dirname + "/../../../create") + (utils.isWindows() ? ".bat" : ""),
     TARGET_COMMAND = path.normalize(appFolder + "cordova/target") + (utils.isWindows() ? ".bat" : "");
 
@@ -41,6 +42,7 @@ function executeScript(shellCommand, args, shouldFail) {
     //console.log(result.output, "\n\n\n");
     //console.log("Finished executing  with code ", result.code, " at ", (new Date()), "\n\n\n");
     _output = result.output;
+    _code = result.code;
 }
 
 describe("cordova/target tests", function () {
@@ -71,7 +73,7 @@ describe("cordova/target tests", function () {
         expect(target.type).toEqual("device");
         expect(target.password).toEqual("pass");
         expect(target.pin).toEqual("DEADBEEF");
-        expect(_output).toEqual("");
+        expect(_code).toEqual(0);
     });
 
     it("should remove a target", function () {


### PR DESCRIPTION
Testing notes [Test the below scenarios on both Mac and Windows]
-Test calling check_reqs by itself to ensure that continues to work for CLI
-Test each platform script (build, run, clean etc) to ensure they continue to work.
-Test that each script calls the check_reqs successfully by calling them without bbndk on the path (or something similar) and verify an error is shown from the check_reqs script.
