### PR TITLE
Significantly improves create script execution time by executing dependencies from .cordova folder instead of copying

### DIFF
--- a/blackberry10/bin/create.js
+++ b/blackberry10/bin/create.js
@@ -34,6 +34,7 @@ var build,
     app_id = process.argv[3],
     TARGETS = ["device", "simulator"],
     TEMPLATE_PROJECT_DIR = path.join(__dirname, "templates", "project"),
+    ROOT_PROJECT_DIR = path.join(__dirname, ".."),
     MODULES_PROJECT_DIR = path.join(__dirname, "..", "node_modules"),
     BOOTSTRAP_PROJECT_DIR = path.join(__dirname, "..", "framework", "bootstrap"),
     FRAMEWORK_LIB_PROJECT_DIR = path.join(__dirname, "..", "framework", "lib"),
@@ -112,32 +113,6 @@ function copyFilesToProject() {
     wrench.mkdirSyncRecursive(project_path, 0777);
     wrench.copyDirSyncRecursive(TEMPLATE_PROJECT_DIR, project_path);
 
-    //copy dependencies folder if exists
-    if (fs.existsSync(path.join(BIN_DIR, "dependencies"))) {
-        //Copy node binaries
-        wrench.mkdirSyncRecursive(path.join(project_path, "cordova", "dependencies", "node"), 0755);
-        wrench.copyDirSyncRecursive(path.join(BIN_DIR, "dependencies", "node"), path.join(project_path, "cordova", "dependencies", "node"));
-
-        //Copy bb-tools bin files
-        wrench.mkdirSyncRecursive(bbtoolsBinDest, 0755);
-
-        if (utils.isWindows()) {
-            bbNativePackager += ".bat";
-            bbSigner += ".bat";
-            bbDeploy += ".bat";
-            bbDebugTokenRequest += ".bat";
-        }
-
-        utils.copyFile(path.join(BIN_DIR, "dependencies", "bb-tools", "bin", bbNativePackager), bbtoolsBinDest);
-        utils.copyFile(path.join(BIN_DIR, "dependencies", "bb-tools", "bin", bbSigner), bbtoolsBinDest);
-        utils.copyFile(path.join(BIN_DIR, "dependencies", "bb-tools", "bin", bbDeploy), bbtoolsBinDest);
-        utils.copyFile(path.join(BIN_DIR, "dependencies", "bb-tools", "bin", bbDebugTokenRequest), bbtoolsBinDest);
-
-        //copy bb-tools lib folder
-        wrench.mkdirSyncRecursive(bbtoolsLibDest, 0755);
-        wrench.copyDirSyncRecursive(path.join(BIN_DIR, "dependencies", "bb-tools", "lib"), bbtoolsLibDest);
-    }
-
     // copy repo level target tool to project
     utils.copyFile(path.join(BIN_DIR, "target"), path.join(project_path, "cordova"));
     utils.copyFile(path.join(BIN_DIR, "target.bat"), path.join(project_path, "cordova"));
@@ -150,6 +125,9 @@ function copyFilesToProject() {
     } else {
         utils.copyFile(path.join(BIN_DIR, "init"), path.join(project_path, "cordova"));
     }
+
+    //copy VERSION file [used to identify corresponding ~/.cordova/lib directory for dependencies]
+    utils.copyFile(path.join(ROOT_PROJECT_DIR, "VERSION"), path.join(project_path));
 
     // change file permission for cordova scripts because ant copy doesn't preserve file permissions
     wrench.chmodSyncRecursive(path.join(project_path,"cordova"), 0700);

--- a/blackberry10/bin/init
+++ b/blackberry10/bin/init
@@ -18,8 +18,9 @@
 #
 #!/bin/sh
 CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-LOCAL_NODE_BIN=$CURRENT_DIR/dependencies/node/bin
-LOCAL_BBTOOLS=$CURRENT_DIR/dependencies/bb-tools/bin
+CORDOVA_HOME_DIR=$HOME/.cordova/lib/blackberry10/cordova/$(cat "$CURRENT_DIR/../VERSION")
+LOCAL_NODE_BIN=$CORDOVA_HOME_DIR/bin/dependencies/node/bin
+LOCAL_BBTOOLS=$CORDOVA_HOME_DIR/bin/dependencies/bb-tools/bin
 
 if [ -z "$CORDOVA_NODE" ]; then
     if [ -x "$LOCAL_NODE_BIN" ]; then

--- a/blackberry10/bin/init.bat
+++ b/blackberry10/bin/init.bat
@@ -18,26 +18,24 @@ goto comment
        under the License.
 :comment
 
-set LOCAL_NODE_BINARY=%~dps0dependencies\node\bin
-set LOCAL_BBTOOLS_BINARY=%~dps0dependencies\bb-tools\bin
-
-
+set /P CORDOVA_VERSION=<%~dps0..\VERSION
+set CORDOVA_HOME_DIR=%HOME%\.cordova\lib\blackberry10\cordova\%CORDOVA_VERSION%
+set LOCAL_NODE_BINARY=%CORDOVA_HOME_DIR%\bin\dependencies\node\bin
+set LOCAL_BBTOOLS_BINARY=%CORDOVA_HOME_DIR%\bin\dependencies\bb-tools\bin
 
 if defined CORDOVA_NODE ( goto bbtools )
 
 if exist "%LOCAL_NODE_BINARY%" (
     set CORDOVA_NODE=%LOCAL_NODE_BINARY%
 ) else (
+    set FOUNDNODE=
     for %%e in (%PATHEXT%) do (
         for %%X in (node%%e) do (
             if not defined FOUNDNODE (
                 set FOUNDNODE=%%~$PATH:X
+                for %%F in ("%%~$PATH:X") do set CORDOVA_NODE=%%~dpF
             )
         )
-    )
-
-    if defined FOUNDNODE (
-        for %%F in ("%FOUNDNODE%") do set CORDOVA_NODE=%%~dpF
     )
 )
 
@@ -48,15 +46,13 @@ if defined CORDOVA_BBTOOLS ( exit /B )
 if exist "%LOCAL_BBTOOLS_BINARY%" (
     set CORDOVA_BBTOOLS=%LOCAL_BBTOOLS_BINARY%
 ) else (
+    set FOUNDBBTOOLS=
     for %%e in (%PATHEXT%) do (
         for %%X in (blackberry-nativepackager%%e) do (
             if not defined FOUNDBBTOOLS (
                 set FOUNDBBTOOLS=%%~$PATH:X
+                for %%F in ("%%~$PATH:X") do set CORDOVA_BBTOOLS=%%~dpF
             )
         )
-    )
-
-    if defined FOUNDBBTOOLS (
-        for %%F in ("%FOUNDBBTOOLS%") do set CORDOVA_BBTOOLS=%%~dpF
     )
 )


### PR DESCRIPTION
This should roughly cut our create execution time in half. The change is most beneficial on Windows where create takes much longer to execute.

Please ensure this is tested on all OS including windows 7 64 bit.
