### PR TITLE
Fix syntax issue in definition check in init.bat

### DIFF
--- a/blackberry10/bin/init.bat
+++ b/blackberry10/bin/init.bat
@@ -23,7 +23,7 @@ set LOCAL_BBTOOLS_BINARY=%~dps0dependencies\bb-tools\bin
 
 
 
-if defined %CORDOVA_NODE% { goto bbtools }
+if defined CORDOVA_NODE ( goto bbtools )
 
 if exist "%LOCAL_NODE_BINARY%" (
     set CORDOVA_NODE=%LOCAL_NODE_BINARY%
@@ -43,7 +43,7 @@ if exist "%LOCAL_NODE_BINARY%" (
 
 :bbtools
 
-if defined %CORDOVA_BBTOOLS% { exit /B }
+if defined CORDOVA_BBTOOLS ( exit /B )
 
 if exist "%LOCAL_BBTOOLS_BINARY%" (
     set CORDOVA_BBTOOLS=%LOCAL_BBTOOLS_BINARY%


### PR DESCRIPTION
Issue reported on JIRA : [CB-5073](https://issues.apache.org/jira/browse/CB-5073)

Fix syntax issue in init.bat :

```
if defined %CORDOVA_NODE% { ... }
```

become

```
if defined CORDOVA_NODE ( ... )
```
