### PR TITLE
[CB-5258] use exit library

### DIFF
--- a/blackberry10/bin/check_reqs.js
+++ b/blackberry10/bin/check_reqs.js
@@ -19,6 +19,7 @@
 
 var MIN_NODE_VER = "0.9.9",
     ERROR_VALUE = 2,
+    exit = require('exit'),
     signingUtils = require('./lib/signing-utils');
 
 function isNodeNewerThanMin () {
@@ -30,7 +31,7 @@ function isNodeNewerThanMin () {
 
 if (!isNodeNewerThanMin()) {
     console.log("Node version '" + process.versions.node + "' is not new enough. Please upgrade to " + MIN_NODE_VER + " or newer. Aborting.");
-    process.exit(ERROR_VALUE);
+    exit(ERROR_VALUE);
 }
 
 if (!signingUtils.getKeyStorePath()) {
@@ -46,4 +47,4 @@ if (!signingUtils.getKeyStorePathBBID()) {
     }
 }
 
-process.exit(0);
+exit(0);

--- a/blackberry10/bin/create.js
+++ b/blackberry10/bin/create.js
@@ -26,6 +26,7 @@
 
 var build,
     path = require("path"),
+    exit = require('exit'),
     fs = require("fs")
     os = require("os"),
     wrench = require("wrench"),
@@ -69,7 +70,7 @@ function validateProjectPath() {
     if (!process.argv[2]) {
         console.log("You must give a project PATH");
         help();
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
         return "";
     } else {
         return path.resolve(process.argv[2]);
@@ -80,7 +81,7 @@ function validate() {
     if (fs.existsSync(project_path)) {
         console.log("The project path must be an empty directory");
         help();
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
     }
     if (!validPackageName(app_id)) {
         console.log("[warning] App ID must be sequence of alpha-numeric (optionally separated by '.') characters, no longer than 50 characters.\n" +
@@ -190,10 +191,10 @@ if ( process.argv[2] === "-h" || process.argv[2] === "--help" ) {
         copyFilesToProject();
         updateProject();
         clean();
-        process.exit();
+        exit();
     } catch (ex) {
         console.log("Project creation failed!");
         console.error(os.EOL + ex);
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
     }
 }

--- a/blackberry10/bin/lib/target.js
+++ b/blackberry10/bin/lib/target.js
@@ -16,6 +16,7 @@
  */
 
 var path = require('path'),
+    exit = require('exit'),
     fs = require('fs'),
     utils = require('./utils'),
     commander = require('commander'),
@@ -38,7 +39,7 @@ function isValidIp(ip) {
     if (typeof ip !== 'string') {
         console.log("IP is required");
         console.log(commander.helpInformation());
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
     } else {
         ipArray = ip.split('.');
         if (ipArray.length !== 4) {
@@ -60,7 +61,7 @@ function isValidType(type) {
     if (typeof type !== 'string') {
         console.log("target type is required");
         console.log(commander.helpInformation());
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
     }
     else if (!(type === 'device' || type === 'simulator')) {
         result = false;
@@ -99,7 +100,7 @@ commander
         if (commander.args.length === 1) {
             console.log("Target details not specified");
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         name = commander.args[0];
         ip = commander.args[1];
@@ -113,17 +114,17 @@ commander
         if (!isValidIp(ip)) {
             console.log("Invalid IP: " + ip);
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         if (!isValidType(type)) {
             console.log("Invalid target type: " + type);
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         if (!isValidPin(pin)) {
             console.log("Invalid PIN: " + pin);
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         if (properties.targets.hasOwnProperty(name)) {
             console.log("Overwriting target: " + name);
@@ -138,13 +139,13 @@ commander
         if (commander.args.length === 1) {
             console.log('No target specified');
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         name = commander.args[0];
         if (!properties.targets.hasOwnProperty(name)) {
             console.log("Target: '" + name + "' not found");
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
         if (name === properties.defaultTarget) {
             console.log("Deleting default target, please set a new default target");
@@ -159,7 +160,7 @@ commander
     .action(function () {
         if (commander.args.length === 1) {
             console.log(properties.defaultTarget);
-            process.exit();
+            exit();
         }
         name = commander.args[0];
         if (properties.targets.hasOwnProperty(name)) {
@@ -167,7 +168,7 @@ commander
         } else {
             console.log("Target '" + name + "' not found");
             console.log(commander.helpInformation());
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         }
     });
 
@@ -176,7 +177,7 @@ commander
     .action(function () {
         console.log('Unrecognized command');
         console.log(commander.helpInformation());
-        process.exit(NOTIMPLEMENTED_VALUE);
+        exit(NOTIMPLEMENTED_VALUE);
     });
 
 
@@ -191,7 +192,7 @@ try {
                 console.log('  ' + target);
             }
         });
-        process.exit();
+        exit();
     }
     if (Object.keys(properties.targets).length === 1) {
         properties.defaultTarget = Object.keys(properties.targets)[0];
@@ -200,5 +201,5 @@ try {
     utils.writeToPropertiesFile(properties);
 } catch (e) {
     console.log(e);
-    process.exit();
+    exit();
 }

--- a/blackberry10/bin/lib/update.js
+++ b/blackberry10/bin/lib/update.js
@@ -20,6 +20,7 @@
 */
 
 var shell = require('shelljs'),
+    exit = require('exit'),
     path  = require('path'),
     fs    = require('fs'),
     ROOT    = path.join(__dirname, '..', '..');
@@ -86,7 +87,7 @@ if (require.main === module) {
         var args = process.argv;
         if (args.length < 3 || (args[2] == '--help' || args[2] == '-h')) {
             console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'update')) + ' <path_to_project>');
-            process.exit(1);
+            exit(1);
         } else {
             exports.updateProject(args[2]);
         }

--- a/blackberry10/bin/lib/utils.js
+++ b/blackberry10/bin/lib/utils.js
@@ -15,6 +15,7 @@
  */
 
 var fs = require('fs'),
+    exit = require('exit'),
     async = require('async'),
     path = require('path'),
     childProcess = require('child_process'),
@@ -365,9 +366,9 @@ _self = {
             } else {
                 console.error("An error has occurred");
             }
-            process.exit(ERROR_VALUE);
+            exit(ERROR_VALUE);
         } else {
-            process.exit(0);
+            exit(0);
         }
     }
 

--- a/blackberry10/bin/templates/project/cordova/lib/build.js
+++ b/blackberry10/bin/templates/project/cordova/lib/build.js
@@ -17,6 +17,7 @@
  */
 
 var path = require("path"),
+    exit = require("exit"),
     command = require("commander"),
     os = require("os"),
     utils = require("./utils"),
@@ -59,7 +60,7 @@ try {
     if (command.debug && command.release) {
         console.error("Invalid build command: cannot specify both debug and release parameters.");
         console.log(command.helpInformation());
-        process.exit(ERROR_VALUE);
+        exit(ERROR_VALUE);
     }
 
     utils.series(
@@ -117,6 +118,6 @@ try {
     );
 } catch (e) {
     console.error(os.EOL + e);
-    process.exit(ERROR_VALUE);
+    exit(ERROR_VALUE);
 }
 

--- a/blackberry10/package.json
+++ b/blackberry10/package.json
@@ -26,6 +26,7 @@
     "validator": "0.4.1",
     "wrench": "1.4.4",
     "shelljs":"0.1.3",
+    "exit": "0.1.1",
     "elementtree": "0.1.5",
     "prompt": "0.2.11",
     "async": "0.2.9"


### PR DESCRIPTION
On Windows, if you have pending bits in pipes and you exit, they
generally do not get delivered.

To avoid this, you need to change process.exit() to something
which actually ensures that buffers are flushed before it exits,
this is handled by the 'exit' module/function.
