### PR TITLE
CB-5468 improve config.xml encoding handling

### DIFF
--- a/blackberry10/bin/templates/project/cordova/lib/packager-utils.js
+++ b/blackberry10/bin/templates/project/cordova/lib/packager-utils.js
@@ -140,7 +140,7 @@ _self = {
             } else if (data.length >= 3 && data[0] === 0xEF && data[1] === 0xBB && data[2] === 0xBF) {
                 s = data.toString("utf8", 3);
             } else {
-                s = data.toString("ascii");
+                s = data.toString("utf8");
             }
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-5468

Assume files without a BOM are UTF-8 anyway
