### PR TITLE
Don't call cordova.fireDocumentEvent for pause/resume events unless cord...

### DIFF
--- a/blackberry10/framework/lib/framework.js
+++ b/blackberry10/framework/lib/framework.js
@@ -24,13 +24,13 @@ var utils = require('./utils'),
         pause: {
             event: "inactive",
             trigger: function () {
-                webview.executeJavascript("cordova.fireDocumentEvent('pause')");
+                webview.executeJavascript("if (cordova) cordova.fireDocumentEvent('pause')");
             }
         },
         resume: {
             event: "active",
             trigger: function () {
-                webview.executeJavascript("cordova.fireDocumentEvent('resume')");
+                webview.executeJavascript("if (cordova) cordova.fireDocumentEvent('resume')");
             }
         }
     };


### PR DESCRIPTION
...ova object is available

BB10 inactive/active events are mapped to Cordova events,
but they shouldn't trigger an exception if cordova.js isn't included
