### PR TITLE
CB-5723 Build script should accept -l param as it does --loglevel

### DIFF
--- a/blackberry10/README.md
+++ b/blackberry10/README.md
@@ -103,14 +103,14 @@ where
 
 To build your app in release mode, on the command line, type the following command:
 
-        <path-to-project>/cordova/build debug [<target>] [-k|--keystorepass <password>] [-p|--params <params-JSON-file>] [-ll|--loglevel <error|warn|verbose>]
+        <path-to-project>/cordova/build debug [<target>] [-k|--keystorepass <password>] [-p|--params <params-JSON-file>] [-l|--loglevel <error|warn|verbose>]
 
 where
 
 -   `<target>`  specifies the name of a previously added target. If `<target>`  is not specified, the default target is used, if one has been created. This argument is only required if you want the script to deploy your app to a BlackBerry device or emulator and you have not created a default target. Additionally, if `<target>`  is a device, then that device must be connected to your computer by USB connection or be connected to the same Wi-Fi network as your computer.
 -   `-k|--keystorepass <password>`  specifies the password you defined when you configured your computer to sign applications. This password is also used to create your debug token. This argument is only required if you want the script to create and install the debug token for you.
 -   `-p|--params <params-JSON-file>`  specifies a JSON file containing additional parameters to pass to downstream tools.
--   `-ll|--loglevel <level>`  specifies the log level. The log level may be one of `error`, `warn`, or `verbose`.
+-   `-l|--loglevel <level>`  specifies the log level. The log level may be one of `error`, `warn`, or `verbose`.
 
 Note that all of these parameters are optional. If you have previously defined a default target (and installed a debug token, if that target is a BlackBerry device), you can run the script with no arguments, and the script will package your app and deploy it to the default target. For example:
 

--- a/blackberry10/bin/templates/project/cordova/lib/build.js
+++ b/blackberry10/bin/templates/project/cordova/lib/build.js
@@ -45,7 +45,7 @@ function copyArgIfExists(arg) {
 }
 
 command
-    .usage('[--debug | --release] [--query] [-k | --keystorepass] [-b <number> | --buildId <number>] [-p <json> | --params <json>] [-ll <level> | --loglevel <level>] [--web-inspector] [--no-signing]')
+    .usage('[--debug | --release] [--query] [-k | --keystorepass] [-b <number> | --buildId <number>] [-p <json> | --params <json>] [-l <level> | --loglevel <level>] [--web-inspector] [--no-signing]')
     .option('--debug', 'build in debug mode.')
     .option('--release', 'build in release mode. This will sign the resulting bar.')
     .option('--query', 'query on the commandline when a password is needed')

--- a/blackberry10/bin/templates/project/cordova/lib/cmdline.js
+++ b/blackberry10/bin/templates/project/cordova/lib/cmdline.js
@@ -30,7 +30,7 @@ command
     .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
     .option('--appdesc <filepath>', 'Optionally specifies the path to the bar descriptor file (bar-descriptor.xml). For internal use only.')
     .option('-v, --verbose', 'Turn on verbose messages')
-	.option('-ll, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)');
+    .option('-l, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)');
 
 function parseArgs(args) {
     var option,

--- a/blackberry10/bin/templates/project/cordova/lib/run-utils.js
+++ b/blackberry10/bin/templates/project/cordova/lib/run-utils.js
@@ -267,7 +267,7 @@ _self = {
         if (fs.existsSync(barPath)) {
             allDone(null, deployTarget);
         } else {
-            allDone("No build file exists, please run: build [--debug] [--release] [-k | --keystorepass] [-b | --buildId <number>] [-p | --params <json>] [-ll | --loglevel <level>] ");
+            allDone("No build file exists, please run: build [--debug | --release] [-k | --keystorepass] [-b | --buildId <number>] [-p | --params <json>] [-l | --loglevel <level>] ");
         }
     },
 

--- a/blackberry10/bin/test/cordova/unit/spec/lib/cmdline.js
+++ b/blackberry10/bin/test/cordova/unit/spec/lib/cmdline.js
@@ -64,8 +64,8 @@ describe("Command line", function () {
         expect(cmd.loglevel).toBe("warn");
     });
 
-    it("accepts -ll", function () {
-        cmd.parseOptions(["-ll", "error"]);
+    it("accepts -l", function () {
+        cmd.parseOptions(["-l", "error"]);
         expect(cmd.loglevel).toBe("error");
     });
 


### PR DESCRIPTION
This corrects the documentation to consistently say `-l` instead of `-ll`.

It's fall out from https://issues.apache.org/jira/browse/CB-5723

More documentation fixes live in https://github.com/blackberry/cordova-blackberry/tree/fix_documentation_etc
