### PR TITLE
CB-6241 Default to prompting for passwords (replace --query with --no-qu...

### DIFF
--- a/blackberry10/README.md
+++ b/blackberry10/README.md
@@ -90,13 +90,12 @@ To build your app, run the `build` script. You can build the app in either *rele
 
 To build your app in release mode, on the command line, type the following command:
 
-        <path-to-project>/cordova/build release [<target>] <--query | --keystorepass <password>> [--buildId <number>] [--params <params-JSON-file>]
+        <path-to-project>/cordova/build release [<target>] [--keystorepass <password>] [--buildId <number>] [--params <params-JSON-file>]
 
 where
 
 -   `<target>`  specifies the name of a previously added target. If `<target>`  is not specified, the default target is used, if one has been created. This argument is only required if you want the script to deploy your app to a BlackBerry device or emulator and you have not created a default target. Additionally, if `<target>`  is a device, then that device must be connected to your computer by USB connection or be connected to the same Wi-Fi network as your computer.
--   `--query`  will cause you to be prompted for your keystore password
--   `--keystorepass <password>`  specifies the password you defined when you configured your computer to sign applications.
+-   `--keystorepass <password>`  specifies the password you defined when you configured your computer to sign applications (by default you'll be prompted for this if it isn't otherwise configured).
 -   `--buildId <number>`  specifies the build version number of your application. Typically, this number should be incremented from the previous signed version. This argument is optional.
 -   `--params <params-JSON-file>`  specifies a JSON file containing additional parameters to pass to downstream tools. This argument is optional.
 

--- a/blackberry10/bin/templates/project/cordova/lib/build.js
+++ b/blackberry10/bin/templates/project/cordova/lib/build.js
@@ -45,10 +45,10 @@ function copyArgIfExists(arg) {
 }
 
 command
-    .usage('[--debug | --release] [--query] [-k | --keystorepass] [-b <number> | --buildId <number>] [-p <json> | --params <json>] [-l <level> | --loglevel <level>] [--web-inspector] [--no-signing]')
+    .usage('[--debug | --release] [--no-query] [-k | --keystorepass] [-b <number> | --buildId <number>] [-p <json> | --params <json>] [-l <level> | --loglevel <level>] [--web-inspector] [--no-signing]')
     .option('--debug', 'build in debug mode.')
     .option('--release', 'build in release mode. This will sign the resulting bar.')
-    .option('--query', 'query on the commandline when a password is needed')
+    .option('--no-query', 'fail if a password is needed and one isn\'t available')
     .option('-k, --keystorepass <password>', 'signing key password')
     .option('-b, --buildId <num>', 'specifies the build number for signing (typically incremented from previous signing).')
     .option('-p, --params <params JSON file>', 'specifies additional parameters to pass to downstream tools.')
@@ -95,7 +95,7 @@ try {
                                 done();
                             });
                         } else {
-                            err = "No signing password provided. Please enter a value for 'keystorepass' in " + pkgrUtils.homedir() + "/.cordova/blackberry10.json or use --keystorepass via command-line";
+                            err = "No signing password provided. You can omit --no-query, use --no-signing, use --keystorepass, or enter a value for 'keystorepass' in " + pkgrUtils.homedir() + "/.cordova/blackberry10.json";
                         }
                     }
                 }

--- a/blackberry10/bin/templates/project/cordova/lib/run-utils.js
+++ b/blackberry10/bin/templates/project/cordova/lib/run-utils.js
@@ -113,7 +113,7 @@ function validateTarget(options, targetName, allDone) {
                         });
                     });
                 } else if (!options.emulator) {
-                    err = "Please provide device password using --devicepass or add one to the target " + deployTarget.name + " defined at " + utils.getPropertiesFilePath();
+                    err = "No device password provided. You can omit --no-query, use --devicepass, or enter a value for 'password' to the target " + deployTarget.name + " defined at " + utils.getPropertiesFilePath();
                 }
             }
         }

--- a/blackberry10/bin/templates/project/cordova/lib/run.js
+++ b/blackberry10/bin/templates/project/cordova/lib/run.js
@@ -42,14 +42,14 @@ function install(deployTarget, done) {
 }
 
 options
-    .usage('[--device] [--emulator] [--target=<id>] [--release] [--query] [-k | --keystorepass] [--devicepass] [--no-launch] [--no-uninstall] [--no-build]')
+    .usage('[--device] [--emulator] [--target=<id>] [--release] [--no-query] [-k | --keystorepass] [--devicepass] [--no-launch] [--no-uninstall] [--no-build]')
     .option('-k, --keystorepass <password>', 'the password of signing key; needed for creating debug token')
     .option('--device', 'run on connected device')
     .option('--emulator', 'run on BB10 simulator')
     .option('--devicepass <password>', 'device password')
     .option('--target <id>', 'specifies the target to run the application')
     .option('--release', 'build in release mode')
-    .option('--query', 'query on the commandline when a password is needed')
+    .option('--no-query', 'fail if no password is provided and one is needed')
     .option('--no-launch', 'do not launch the application on device')
     .option('--no-build', 'deploy the pre-built bar file and skip building')
     .on('--help', function () {


### PR DESCRIPTION
...ery)

https://issues.apache.org/jira/browse/CB-6241

As a consequence, if you don't specify --no-query, and a password is needed,
you will be prompted.

If you have a build script which includes --query, the build will fail.
