### PR TITLE
Tweak whitelist URI parsing to fix whitelist issues with @2x resource na...

### DIFF
--- a/blackberry10/framework/lib/utils.js
+++ b/blackberry10/framework/lib/utils.js
@@ -366,7 +366,7 @@ self = module.exports = {
     parseUri : function (str) {
         var i, uri = {},
             key = [ "source", "scheme", "authority", "userInfo", "user", "password", "host", "port", "relative", "path", "directory", "file", "query", "anchor" ],
-            matcher = /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/.exec(str);
+            matcher = /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@\/]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/.exec(str);
 
         for (i = key.length - 1; i >= 0; i--) {
             uri[key[i]] = matcher[i] || "";

--- a/blackberry10/framework/test/unit/lib/policy/whitelist.js
+++ b/blackberry10/framework/test/unit/lib/policy/whitelist.js
@@ -453,6 +453,20 @@ describe("whitelist", function () {
             expect(whitelist.isFeatureAllowed("http://google.com/folder", "blackberry.media.camera")).toEqual(true);
         });
 
+        it("can allow access to whitelisted HTTP URLs with @2x in the file name", function () {
+            var whitelist = new Whitelist({
+                hasMultiAccess : false,
+                accessList : [{
+                    uri : "http://google.com",
+                    allowSubDomain : true,
+                    features : null
+                }]
+            });
+
+            expect(whitelist.isAccessAllowed("http://www.google.com/image@2x.png")).toEqual(true);
+            expect(whitelist.isAccessAllowed("http://www.cnn.com/image@2x.png")).toEqual(false);
+        });
+
         describe("when access uris have subdomains", function () {
             it("can get whitelisted features for subdomains", function () {
                 var whitelist = new Whitelist({


### PR DESCRIPTION
...ming

Image filenames containing "@2x" were causing parsing issues with the parseUri() regex. This patch adjusts the regex to prevent parsing errors with "@2x" filenames.
