### PR TITLE
CB-7186 --no-signing will be ignored if --buildId is set

### DIFF
--- a/bin/templates/project/cordova/lib/build.js
+++ b/bin/templates/project/cordova/lib/build.js
@@ -81,8 +81,10 @@ try {
                     keystorepass = session.getKeyStorePass(command),
                     err;
 
+                copyArgIfExists("buildId");
+                copyArgIfExists("signing");
+
                 if (command.release) {
-                    copyArgIfExists("buildId");
                     if (command.signing) {
                         //Note: Packager refers to signing password as "password" not "keystorepass"
                         bbwpArgv.push("--password");

--- a/bin/templates/project/cordova/lib/cmdline.js
+++ b/bin/templates/project/cordova/lib/cmdline.js
@@ -20,7 +20,7 @@ var command = require("commander"),
 
 command
     .version('1.0.0.0')
-    .usage('[drive:][path]archive [-s [dir]] [[ -g genpassword] [-buildId num]] [-o dir] [-d] [-p paramsjsonfile]')
+    .usage('[drive:][path]archive [-s [dir]] [[ -g genpassword] [-buildId num]] [-o dir] [-d] [-p paramsjsonfile] [--signing]')
     .option('-s, --source [dir]', 'Save source. The default behavior is to not save the source files. If dir is specified then creates dir\\src\\ directory structure. If no dir specified then the path of archive is assumed')
     .option('-g, --password <password>', 'Signing key password')
     .option('-buildId <num>', '[deprecated] Use --buildId.')
@@ -30,7 +30,8 @@ command
     .option('-p, --params <params JSON file>', 'Specifies additional parameters to pass to downstream tools.')
     .option('--appdesc <filepath>', 'Optionally specifies the path to the bar descriptor file (bar-descriptor.xml). For internal use only.')
     .option('-v, --verbose', 'Turn on verbose messages')
-    .option('-l, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)');
+    .option('-l, --loglevel <loglevel>', 'set the logging level (error, warn, verbose)')
+    .option('--signing', 'indicates the build process is trying to sign the app'); // --signing won't be passed to blackberry-nativepackager, package-validator.js uses this flag to check indicate if it is signing
 
 function parseArgs(args) {
     var option,
@@ -50,14 +51,14 @@ function parseArgs(args) {
     command.parse(args);
 
     //Check for any invalid command line args
-    for (i = 0; i < args.length; i++) {
-        //Remove leading dashes if any
-        option = args[i].substring(2);
-        if (args[i].indexOf("--") === 0 && !command[option]) {
-            throw localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", args[i]);
+    args.forEach(function (arg) {
+        if (typeof arg === "string" && arg.indexOf("--") === 0) {
+            var option = arg.substring(2);
+            if (!command[option]) {
+                throw localize.translate("EXCEPTION_CMDLINE_ARG_INVALID", arg);
+            }
         }
-    }
-
+    });
     return this;
 }
 

--- a/bin/templates/project/cordova/lib/localize.js
+++ b/bin/templates/project/cordova/lib/localize.js
@@ -29,10 +29,10 @@ var Localize = require("localize"),
             "en": "Build ID set in config.xml [version], but signing key file was not found: $[1]"
         },
         "EXCEPTION_MISSING_SIGNING_PASSWORD": {
-            "en": "Cannot sign application - No signing password provided [-g]"
+            "en": "Cannot sign application - No signing password provided [--keystorepass]"
         },
         "WARNING_SIGNING_PASSWORD_EXPECTED": {
-            "en": "Build ID set in config.xml [version], but no signing password was provided [-g]. Bar will be unsigned"
+            "en": "Build ID set in config.xml [version], but no signing password was provided [--keystorepass]. Bar will be unsigned"
         },
         "EXCEPTION_DEBUG_TOKEN_NOT_FOUND": {
             "en": "Failed to find debug token. If you have an existing debug token, please copy it to $[1]. To generate a new debug token, execute the 'run' command."

--- a/bin/templates/project/cordova/lib/packager-validator.js
+++ b/bin/templates/project/cordova/lib/packager-validator.js
@@ -40,6 +40,7 @@ _self = {
             keysPassword = session.storepass && typeof session.storepass === "string",
             commandLinebuildId = session.buildId && typeof session.buildId === "string",//--buildId
             buildId = widgetConfig.buildId && typeof widgetConfig.buildId === "string",//Finalized Build ID
+            signing = session.signing,
 
             //Constants
             AUTHOR_P12 = "author.p12",
@@ -55,35 +56,37 @@ _self = {
                 throw localize.translate("EXCEPTION_MISSING_SIGNING_KEY_FILE", file);
             };
 
-        //If -g <password> or --buildId is set, but signing key files are missing, throw an error
-        if (keysPassword || commandLinebuildId) {
-            if (!keysFound) {
-                signingFileError(AUTHOR_P12);
-            } else if (keysDefault && !cskFound && !bbidFound) {
-                //Only warn about BBID since the old tokens are deprecated
-                signingFileError(BARSIGNER_BBID);
-            } else if (keysDefault && cskFound && !dbFound) {
-                signingFileError(BARSIGNER_DB);
+        if (signing) {
+            //If -g <password> or --buildId is set, but signing key files are missing, throw an error
+            if ((keysPassword || commandLinebuildId)) {
+                if (!keysFound) {
+                    signingFileError(AUTHOR_P12);
+                } else if (keysDefault && !cskFound && !bbidFound) {
+                    //Only warn about BBID since the old tokens are deprecated
+                    signingFileError(BARSIGNER_BBID);
+                } else if (keysDefault && cskFound && !dbFound) {
+                    signingFileError(BARSIGNER_DB);
+                }
+
+            //If a buildId exists in config, but no keys were found, throw a warning
+            } else if (buildId) {
+                if (!keysFound) {
+                    signingFileWarn(AUTHOR_P12);
+                } else if (keysDefault && !cskFound && !bbidFound) {
+                    //Only warn about BBID since the old tokens are deprecated
+                    signingFileWarn(BARSIGNER_BBID);
+                } else if (keysDefault && cskFound && !dbFound) {
+                    signingFileWarn(BARSIGNER_DB);
+                }
             }
 
-        //If a buildId exists in config, but no keys were found, throw a warning
-        } else if (buildId) {
-            if (!keysFound) {
-                signingFileWarn(AUTHOR_P12);
-            } else if (keysDefault && !cskFound && !bbidFound) {
-                //Only warn about BBID since the old tokens are deprecated
-                signingFileWarn(BARSIGNER_BBID);
-            } else if (keysDefault && cskFound && !dbFound) {
-                signingFileWarn(BARSIGNER_DB);
+            if (commandLinebuildId && !keysPassword) {
+                //if --buildId was provided with NO password, throw error
+                throw localize.translate("EXCEPTION_MISSING_SIGNING_PASSWORD");
             }
         }
 
-        if (commandLinebuildId && !keysPassword) {
-            //if --buildId was provided with NO password, throw error
-            throw localize.translate("EXCEPTION_MISSING_SIGNING_PASSWORD");
-        }
-
-        //if --appdesc was provided, but the file is not existing, throw an error
+        //if --appdesc was provided, but the file does not exist, throw an error
         if (session.appdesc && !fs.existsSync(session.appdesc)) {
             throw localize.translate("EXCEPTION_APPDESC_NOT_FOUND", session.appdesc);
         }

--- a/bin/templates/project/cordova/lib/session.js
+++ b/bin/templates/project/cordova/lib/session.js
@@ -57,7 +57,8 @@ module.exports = {
             buildId = cmdline.buildId,
             signerParams = getParams("blackberry-signer", cmdline) || {},
             keystore = signerParams["-keystore"],
-            bbidtoken = signerParams["-bbidtoken"];
+            bbidtoken = signerParams["-bbidtoken"],
+            signing = cmdline.signing;
 
         //If -o option was not provided, default output location is the same as .zip
         outputDir = outputDir || path.dirname(archivePath);
@@ -113,6 +114,7 @@ module.exports = {
             "storepass": signingPassword,
             "buildId": buildId,
             "appdesc" : appdesc,
+            "signing" : signing,
             getParams: function (toolName) {
                 return getParams(toolName, cmdline);
             },


### PR DESCRIPTION
Fixed issue:
1. `webworks build --release --buildId 1234 --no-signing`: `--no-signing` was ignored when a `--buildId` is provided
2. `webworks build [--debug] --buildId 1234`: `--buildId` wasn't set in manifest of bar file in debug build
