### PR TITLE
CB-7807 Adds init_reqs files to Update script

### DIFF
--- a/bin/lib/update.js
+++ b/bin/lib/update.js
@@ -61,6 +61,8 @@ function updateTargetTool(projectpath) {
 function updateInitTool(projectpath) {
     shell.cp('-f', path.join(ROOT, 'bin', 'init.bat'), path.join(projectpath, 'cordova'));
     shell.cp('-f', path.join(ROOT, 'bin', 'init'), path.join(projectpath, 'cordova'));
+    shell.cp('-f', path.join(ROOT, 'bin', 'init_reqs.bat'), path.join(projectpath, 'cordova'));
+    shell.cp('-f', path.join(ROOT, 'bin', 'init_reqs'), path.join(projectpath, 'cordova'));
 }
 
 exports.updateProject = function (projectpath) {


### PR DESCRIPTION
This was missed in CB-7807 and causes an issue on platform update if not included